### PR TITLE
fix: prevent image overflow with padding

### DIFF
--- a/src/lib/components/Post.svelte
+++ b/src/lib/components/Post.svelte
@@ -22,7 +22,7 @@
 
 <div class="card variant-ringed-primary mt-4 overflow-hidden" aria-label={post.title}>
 	<header>
-		<img src="{base}{post.featuredImage}" class="max-h-96 w-full object-contain" alt="" />
+		<img src="{base}{post.featuredImage}" class="max-h-96 w-full object-contain px-px" alt="" />
 	</header>
 	<div class="px-4">
 		<h2 class="m-0">


### PR DESCRIPTION
# Pull request

## Proposed changes

See #91.

Images in the header of blog posts are not overflowing the card's border anymore thanks to the addition of one pixel of padding to the left and to the right, respectively.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved image styling in the post component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->